### PR TITLE
Add Kairali delivery charges calculator

### DIFF
--- a/kairali-delivery.html
+++ b/kairali-delivery.html
@@ -223,7 +223,7 @@ permalink: /kairali-delivery/
     <div class="card">
         <h2>Step 1 &mdash; Select Your Order</h2>
         <div class="product-grid">
-            <div class="product-item" id="item-60" data-weight="200">
+            <div class="product-item" id="item-60" data-weight="60">
                 <div>
                     <div class="product-label">60 g</div>
                     <div class="product-sub">Small bottle</div>
@@ -234,7 +234,7 @@ permalink: /kairali-delivery/
                     <button class="qty-btn" onclick="changeQty('q60', 1)">&#43;</button>
                 </div>
             </div>
-            <div class="product-item" id="item-100" data-weight="280">
+            <div class="product-item" id="item-100" data-weight="100">
                 <div>
                     <div class="product-label">100 g</div>
                     <div class="product-sub">Standard bottle</div>
@@ -245,7 +245,7 @@ permalink: /kairali-delivery/
                     <button class="qty-btn" onclick="changeQty('q100', 1)">&#43;</button>
                 </div>
             </div>
-            <div class="product-item" id="item-250" data-weight="500">
+            <div class="product-item" id="item-250" data-weight="250">
                 <div>
                     <div class="product-label">250 g</div>
                     <div class="product-sub">Family bottle</div>
@@ -256,7 +256,7 @@ permalink: /kairali-delivery/
                     <button class="qty-btn" onclick="changeQty('q250', 1)">&#43;</button>
                 </div>
             </div>
-            <div class="product-item" id="item-500" data-weight="850">
+            <div class="product-item" id="item-500" data-weight="500">
                 <div>
                     <div class="product-label">500 g</div>
                     <div class="product-sub">Value bottle</div>
@@ -309,7 +309,7 @@ permalink: /kairali-delivery/
         <div class="result-charge-value" id="resCharge">—</div>
         <div class="result-charge-note" id="resChargeNote"></div>
         <div class="result-disclaimer">
-            Shipping weight is estimated (product + bottle + packaging). Actual charge is determined at the post office counter by actual weight. Tariff as per India Post Speed Post Parcel rates effective 01.10.2025.
+            Weight shown is total product weight plus 150 g for the outer box. Actual charge is determined at the post office counter by actual weight. Tariff as per India Post Speed Post Parcel rates effective 01.10.2025.
         </div>
     </div>
 
@@ -320,10 +320,10 @@ permalink: /kairali-delivery/
 <script>
 // ── Quantities ──────────────────────────────────────────────────────────────
 const products = {
-    q60:  { itemId: 'item-60',  weight: 200 },
-    q100: { itemId: 'item-100', weight: 280 },
-    q250: { itemId: 'item-250', weight: 500 },
-    q500: { itemId: 'item-500', weight: 850 },
+    q60:  { itemId: 'item-60',  weight: 60  },
+    q100: { itemId: 'item-100', weight: 100 },
+    q250: { itemId: 'item-250', weight: 250 },
+    q500: { itemId: 'item-500', weight: 500 },
 };
 
 function changeQty(id, delta) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new interactive delivery charges calculator page at `/kairali-delivery/`
- Customers select product sizes (60g / 100g / 250g / 500g) and quantities, enter their pincode, and get the exact Speed Post charge
- Uses India Post pincode API + OpenStreetMap Nominatim for geocoding, then Haversine formula to calculate distance from origin pincode 682301 (Kakkanad, Ernakulam)
- Full Oct 2025 Speed Post Parcel tariff table embedded (incl. GST, all 70 weight bands up to 35 kg)
- Weight = sum of product weights + 150 g flat for the outer shipping box (added once per order)
- Adds a "Delivery Charges" nav link to the sidebar on all existing Kairali pages

## Test plan

- [ ] Select one or more products and enter a Kerala pincode — verify Local or ≤200 km zone
- [ ] Enter a north India pincode (e.g. 110001) — verify Above 2000 km zone and correct tariff
- [ ] Enter an invalid pincode — verify error message appears
- [ ] Try ordering 60g + 500g: total should be 60 + 500 + 150 = 710 g → 501–1000 g band
- [ ] Check sidebar link appears on the Kairali Oil and Benefits pages

https://claude.ai/code/session_01EnbZTxFWccFRNTa4BM3nXv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnbZTxFWccFRNTa4BM3nXv)_